### PR TITLE
fix .gitignore empty line, ignore /.gtm/, tests

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -33,8 +33,8 @@ var (
 		"alias.pushgtm":    "push origin refs/notes/gtm-data",
 		"alias.fetchgtm":   "fetch origin refs/notes/gtm-data:refs/notes/gtm-data",
 		"notes.rewriteref": "refs/notes/gtm-data"}
-	// GitIgnore is list of file/path ignores to apply to git repo
-	GitIgnore = ".gtm/"
+	// GitIgnore is file ignore to apply to git repo
+	GitIgnore = "/.gtm/"
 )
 
 const (


### PR DESCRIPTION
Hi, I've noticed that gtm init creates .gitignore file, but first line is empty:

```

.gtm/
```

I've rewrote IgnoreSet function and added testcases.

Also I have changed .gitignore contents from `.gtm/` to `/.gtm/` because  at
the current moment git will ignore all directories and files that contains `.gtm`
suffix.