### PR TITLE
Hooks directory might not be present

### DIFF
--- a/scm/git.go
+++ b/scm/git.go
@@ -372,8 +372,16 @@ func SetHooks(hooks map[string]string, wd ...string) error {
 			}
 		}
 		fp := filepath.Join(p, ".git", "hooks", hook)
+		hooksDir := filepath.Join(p, ".git", "hooks")
 
 		var output string
+
+		if _, err := os.Stat(hooksDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(hooksDir, 0700); err != nil {
+				return err
+			}
+		}
+
 		if _, err := os.Stat(fp); !os.IsNotExist(err) {
 			b, err := ioutil.ReadFile(fp)
 			if err != nil {

--- a/scm/git_test.go
+++ b/scm/git_test.go
@@ -375,4 +375,24 @@ func TestSetGitHooks(t *testing.T) {
 	if !strings.Contains(output, hooks["post-commit"]) {
 		t.Errorf("SetHooks(hooks) expected post-commit to contain %s, got %s", hooks["post-commit"], output)
 	}
+
+	// test if hooks folder doesn't exist
+	err = os.RemoveAll(path.Join(repoPath, ".git", "hooks"))
+	if err != nil {
+		t.Fatalf("SetHooks(hooks) expect error nil, got %s", err)
+	}
+
+	err = SetHooks(hooks, repoPath)
+	if err != nil {
+		t.Errorf("SetHooks(hooks) expect error nil, got %s", err)
+	}
+	b, err = ioutil.ReadFile(path.Join(repoPath, ".git", "hooks", "post-commit"))
+	if err != nil {
+		t.Fatalf("SetHooks(hooks) expect error nil, got %s", err)
+	}
+	output = string(b)
+	if !strings.Contains(output, hooks["post-commit"]) {
+		t.Errorf("SetHooks(hooks) expected post-commit to contain %s, got %s", hooks["post-commit"], output)
+	}
+
 }


### PR DESCRIPTION
I stumbled upon the case where my .git folder didn't have a hooks folder.

This is an uncommon case which happens mostly when pulling code with a tool like smartgit / SourceTree or other but i thought it would be nice to handle it since its not documented and may not be trivial for some.

As a workaround, manually creating the folder works