### PR TITLE
feat(freebsd): FreeBSD 13.0-RELEASE compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
+SHELL          = /usr/local/bin/bash
 BINARY         = bin/gtm
 VERSION        = 0.0.0-dev
 COMMIT         = $(shell git show -s --format='%h' HEAD)
 LDFLAGS        = -ldflags "-X main.Version=$(VERSION)-$(COMMIT)"
-GIT2GO_VERSION = v27
-GIT2GO_PATH    = $(GOPATH)/src/github.com/libgit2/git2go
+GIT2GO_VERSION = v33.0.7
+GIT2GO_PATH    = vendor/github.com/libgit2/git2go/v33
 LIBGIT2_PATH   = $(GIT2GO_PATH)/vendor/libgit2
 PKGS           = $(shell go list ./... | grep -v vendor)
 BUILD_TAGS     = static
@@ -54,29 +55,15 @@ clean:
 	rm bin/*
 
 git2go-install:
-	[[ -d $(GIT2GO_PATH) ]] || git clone https://github.com/libgit2/git2go.git $(GIT2GO_PATH) && \
+	[[ -d $(GIT2GO_PATH)/.git ]] || (rm -rf $(GIT2GO_PATH) && git clone https://github.com/libgit2/git2go.git $(GIT2GO_PATH)) && \
 	cd ${GIT2GO_PATH} && \
-	git pull && \
+	git pull origin $(GIT2GO_VERSION) && \
 	git checkout -qf $(GIT2GO_VERSION) && \
 	git submodule update --init
 
 git2go: git2go-install
-	cd $(LIBGIT2_PATH) && \
-	mkdir -p install/lib && \
-	mkdir -p build && \
-	cd build && \
-	cmake -DTHREADSAFE=ON \
-		  -DBUILD_CLAR=OFF \
-		  -DBUILD_SHARED_LIBS=OFF \
-		  -DCMAKE_C_FLAGS=-fPIC \
-		  -DUSE_SSH=OFF \
-		  -DCURL=OFF \
-		  -DUSE_HTTPS=OFF \
-		  -DUSE_BUNDLED_ZLIB=ON \
-		  -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-		  -DCMAKE_INSTALL_PREFIX=../install \
-		  .. && \
-	cmake --build .
+	cd $(GIT2GO_PATH) && \
+	gmake install-static
 
 git2go-clean:
 	[[ -d $(GIT2GO_PATH) ]] && rm -rf $(GIT2GO_PATH)

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean:
 git2go-install:
 	[[ -d $(GIT2GO_PATH)/.git ]] || (rm -rf $(GIT2GO_PATH) && git clone https://github.com/libgit2/git2go.git $(GIT2GO_PATH)) && \
 	cd ${GIT2GO_PATH} && \
-	git pull origin $(GIT2GO_VERSION) && \
+	git fetch origin $(GIT2GO_VERSION) && \
 	git checkout -qf $(GIT2GO_VERSION) && \
 	git submodule update --init
 

--- a/scm/git.go
+++ b/scm/git.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/git-time-metric/gtm/util"
-	"github.com/libgit2/git2go"
+	"github.com/libgit2/git2go/v33"
 )
 
 // Workdir returns the working directory for a repo
@@ -298,7 +298,7 @@ func DiffParentCommit(childCommit *git.Commit) (CommitStats, error) {
 		files := []string{}
 
 		err := childTree.Walk(
-			func(s string, entry *git.TreeEntry) int {
+			func(s string, entry *git.TreeEntry) error {
 				switch entry.Filemode {
 				case git.FilemodeTree:
 					// directory where file entry is located
@@ -307,7 +307,7 @@ func DiffParentCommit(childCommit *git.Commit) (CommitStats, error) {
 					files = append(files, filepath.Join(path, entry.Name))
 					fileCnt++
 				}
-				return 0
+				return nil
 			})
 
 		if err != nil {

--- a/util/test.go
+++ b/util/test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libgit2/git2go"
+	"github.com/libgit2/git2go/v33"
 )
 
 // TestRepo represents a test git repo used in testing


### PR DESCRIPTION
Fix Makefile to reference correct version of git2go for FreeBSD
13.0-RELEASE
Fix scm/git.go imports to reference correct version of git2go for
FreeBSD 13.0-RELEASE
Fix scm/git.go:301 git2go TreeWalkCallback type changed return type
'int' -> 'error'
Fix util/test.go imports to reference correct version of git2go for
FreeBSD 13.0-RELEASE

* Tags: 13.0-RELEASE FreeBSD